### PR TITLE
Option to enable sticky sessions for web UI

### DIFF
--- a/geoserver/latest/templates/ingress-webui.yaml
+++ b/geoserver/latest/templates/ingress-webui.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress_webui.enabled -}}
+{{- $fullName := include "geoserver.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress_webui.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress_webui.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress_webui.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-webui
+  labels:
+    {{- include "geoserver.labels" . | nindent 4 }}
+  {{- with .Values.ingress_webui.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress_webui.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress_webui.className }}
+  {{- end }}
+  {{- if .Values.ingress_webui.tls }}
+  tls:
+    {{- range .Values.ingress_webui.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress_webui.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -59,6 +59,30 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# The below is needed to fix login when replicas >2 (HA)
+ingress_webui:
+  enabled: false # Flip this to "true" when replica >2
+  className: ""
+  annotations:
+    nginx.ingress.kubernetes.io/affinity: 'cookie'
+    # cookie path has to be /geoserver so it can match BOTH /geoserver/j_spring_security_check AND /geoserver/web
+    nginx.ingress.kubernetes.io/session-cookie-path: '/geoserver'
+  hosts:
+    - host: geoserver.local
+      paths:
+        - path: /geoserver/web
+          pathType: ImplementationSpecific
+          backend:
+            serviceName: geoserver
+            servicePort: 8080
+    - host: geoserver.local
+      paths:
+        - path: /geoserver/j_spring_security_check
+          pathType: ImplementationSpecific
+          backend:
+            serviceName: geoserver
+            servicePort: 8080
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
(This is an [opt-in](https://github.com/mo3rfan/charts/pull/1/files#diff-5ec54013536da1a035409ffa7515f4a5cc00fcc4b0dff869608cb56ad99e3014R64) feature)

This is needed to ensure the user can stay logged-in when we have the active clustering mode enabled.

Summary:

- A separate ingress is created just for handling the login problem in the webui.
- This ingress is annotated with the sticky session cookie.
- These cookies will only be valid for `/geoserver/web` and `/geoserver/j_spring_security_check` which are relevant to the login form.

Fixes https://github.com/geosolutions-it/DevOps/issues/1605